### PR TITLE
Feature/target param

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ cluster02:
   nutanix_password: qwertz
 ```
 
-# Prometheus extendended Configuration
+# Prometheus extended Configuration
 
 Nutanix Config:
 ```
@@ -45,7 +45,7 @@ nutanix02.cluster.local:
 Prometheus Config:
 ```
 scrape_configs:
-  - job_name: nutanix_export
+  - job_name: nutanix_exporter
     metrics_path: /metrics
     static_configs:
     - targets:
@@ -54,11 +54,44 @@ scrape_configs:
     relabel_configs:
     - source_labels: [__address__]
       target_label: __param_section
-    - source_labels: [__address__]
-      target_label: __param_target
-    - source_labels: [__param_target]
+    - source_labels: [__param_section]
       target_label: instance
     - target_label: __address__
       replacement: nutanix_exporter:9405
 ```
 
+# Prometheus extended configuration, passing the target
+
+Alternatively, you can pass the cluster via the 'target' parameter - this will
+override the 'nutanix_host' setting in the specified section (or the 'default'
+section if no section is specified).  If the target is not a URL, it is assumed
+to be a HTTPS connection to port 9440.
+
+Nutanix Config:
+```
+default:
+  nutanix_host: ignored
+  nutanix_user: prometheus
+  nutanix_password: p@ssw0rd
+
+```
+
+Prometheus Config:
+```
+scrape_configs:
+  - job_name: nutanix_exporter
+    metrics_path: /metrics
+    params:
+      section: [default]
+    static_configs:
+    - targets:
+      - nutanix.cluster.local
+      - nutanix02.cluster.local
+    relabel_configs:
+    - source_labels: [__address__]
+      target_label: __param_target
+    - source_labels: [__param_target]
+      target_label: instance
+    - target_label: __address__
+      replacement: 127.0.0.1:9405
+```

--- a/internal/nutanix/nutanix.go
+++ b/internal/nutanix/nutanix.go
@@ -79,3 +79,12 @@ func NewNutanix(url string, username string, password string) *Nutanix {
 		password: password,
 	}
 }
+
+// Parse optional target param; if it looks like a bare string, add scheme and
+// default port (9440)
+func ParseTarget(target string) string {
+	if !strings.HasPrefix(target, "http") {
+		return "https://" + target + ":9440"
+	}
+	return target
+}

--- a/main.go
+++ b/main.go
@@ -95,6 +95,12 @@ func main() {
 			return
 		}
 
+		target := params.Get("target")
+		if len(target) != 0 {
+			log.Infof("Using target parameter '%s'", target)
+			*nutanixURL = nutanix.ParseTarget(target)
+		}
+
 		log.Infof("Host: %s", *nutanixURL)
 
 		nutanixAPI := nutanix.NewNutanix(*nutanixURL, *nutanixUser, *nutanixPassword)


### PR DESCRIPTION
This adds optional support for passing a 'target' parameter - if it is passed it will override the 'nutanix_host' setting from the config file.

There's some minor magic in that it will prepend 'https://' and append ':9440' to the target if it looks like a bare string (i.e., if it doesn't start with 'http').

This moves nutanix-exporter closer to the semi-standard blackbox_exporter pattern of passing the target to probe along with the config section that contains the credentials.  In my use case, I'd have a single 'default' section with the credentials used across all of the Nutanix clusters and I'll use 'target' to specify the target at scrape time.

Otherwise you have to maintain the list of Nutanix clusters both in the Prometheus config as well as matching entries in the nutanix-exporter config.

Note that, currently, the 'Prometheus Config' section of the README sets 'target', but this exporter doesn't use it.  This PR would make that actually work;  with some minor modifications;  I've updated the README with an example.

If we'd like it to match the blackbox_exporter pattern even closer, we can make 'module' be a synonym for 'section' (while remaining backwards-compatible).